### PR TITLE
update to Keycloak version 26.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ features:
  - ```cd keycloak-plugins```
  - ```mvn clean install```
 ### Configure Keycloak (based on Quarkus)
-***requirements***: [keycloak 26.5.4(https://github.com/keycloak/keycloak/releases/download/26.5.4/keycloak-26.5.4.zip)
+***requirements***: [keycloak 26.5.5(https://github.com/keycloak/keycloak/releases/download/26.5.5/keycloak-26.5.5.zip)
 ```bash
 cp ${SOURCE}/keycloak-plugins/radius-plugin/target/radius-plugin-*.jar \
    ${SOURCE}/keycloak-plugins/rad-sec-plugin/target/rad-sec-plugin-*.jar \
@@ -73,7 +73,7 @@ cp ${SOURCE}/keycloak-plugins/radius-plugin/target/radius-plugin-*.jar \
      ${KEYCLOAK_PATH}/providers/
 ```
 where
-- **KEYCLOAK_PATH** - Path where you are unpacked keycloak-26.5.4.zip [(you can use RADIUS_CONFIG_PATH instead of KEYCLOAK_PATH)](#environment-variables)
+- **KEYCLOAK_PATH** - Path where you are unpacked keycloak-26.5.5.zip [(you can use RADIUS_CONFIG_PATH instead of KEYCLOAK_PATH)](#environment-variables)
 - **SOURCE** - Path where you checked out the code and built the project
 
 ### Environment Variables
@@ -148,7 +148,7 @@ where
    -  **externalDictionary** - path to the dictionary file in freeradius format
 ## Run Keycloak Locally
    ```bash
-cd keycloak-26.5.4
+cd keycloak-26.5.5
 sh bin/kc.sh --debug 8190 start-dev --http-port=8090 --features-disabled=organization
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.5.4
+FROM quay.io/keycloak/keycloak:26.5.5
 LABEL author="Vasyl Zakharchenko"
 LABEL email="vaszakharchenko@gmail.com"
 LABEL name="keycloak-radius-plugin"

--- a/docker/docker-compose-keycloak.yaml
+++ b/docker/docker-compose-keycloak.yaml
@@ -8,7 +8,7 @@ version: "3.5"
 services:
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5.4
+    image: quay.io/keycloak/keycloak:26.5.5
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin

--- a/docs/release/1.6.2.txt
+++ b/docs/release/1.6.2.txt
@@ -3,3 +3,4 @@
 - update to Keycloak version 26.5.4
 - update test dependencies
 - update Maven plugins and plugin dependencies
+- update to Keycloak version 26.5.5

--- a/keycloak-plugins/pom.xml
+++ b/keycloak-plugins/pom.xml
@@ -74,7 +74,7 @@
 
     <!-- dependency versions -->
     <vzakharchenko-tinyradius-netty.version>1.1.4.1</vzakharchenko-tinyradius-netty.version>
-    <keycloak.version>26.5.4</keycloak.version>
+    <keycloak.version>26.5.5</keycloak.version>
 
     <!-- dependency versions provided by the selected ${keycloak.version} -->
     <!-- use: find ../keycloak/target/keycloak -name "*.jar" |cut -d/ -f 5- | sort \

--- a/keycloak/buildAndStartDb.sh
+++ b/keycloak/buildAndStartDb.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-kc_ver='26.5.4'
+kc_ver='26.5.5'
 kc_dir="target/keycloak/keycloak-$kc_ver"
 
 cd ../keycloak

--- a/keycloak/init.sh
+++ b/keycloak/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-kc_ver='26.5.4'
+kc_ver='26.5.5'
 kc_url="https://github.com/keycloak/keycloak/releases/download/$kc_ver/keycloak-$kc_ver.zip"
 kc_zip="keycloak-distribution-$kc_ver.zip"
 

--- a/keycloak/pom.xml
+++ b/keycloak/pom.xml
@@ -7,7 +7,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <keycloak.version>26.5.4</keycloak.version>
+    <keycloak.version>26.5.5</keycloak.version>
     <production>false</production>
     <keycloak-plugin.version>${project.version}</keycloak-plugin.version>
   </properties>

--- a/keycloak/saveDb.sh
+++ b/keycloak/saveDb.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-kc_ver='26.5.4'
+kc_ver='26.5.5'
 kc_dir="target/keycloak/keycloak-$kc_ver"
 timestamp="$(date +%Y%m%d-%H%M%S)"
 

--- a/keycloak/start.sh
+++ b/keycloak/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-kc_ver='26.5.4'
+kc_ver='26.5.5'
 kc_dir="target/keycloak/keycloak-$kc_ver"
 
 cd "${kc_dir}"


### PR DESCRIPTION
- switch from Keycloak 26.5.4 to 26.5.5 
Security fixes:
  - CVE-2026-3047 SAML broker: Authentication bypass due to disabled SAML client completing IdP-initiated login
  - CVE-2026-3009 Improper Enforcement of Disabled Identity Provider in IdentityBrokerService
  - CVE-2026-2603 Disabled SAML IdP still allows IdP-initiated broker login
  - CVE-2026-2092 saml broker encrypted assertion injection

- provided dependencies have not changed